### PR TITLE
ci: restore emulator job for BDD真跑

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,63 @@ jobs:
       # 产物（unsigned APK）不上传，只看 build 是否绿。
       - name: Assemble release (unsigned smoke)
         run: ./gradlew :app:assembleRelease --stacktrace
+
+  # P8.2 Fix-W3 / Fix-WidgetBdd: 真在 emulator 跑 widget BDD instrumented test。
+  # connectedDebugAndroidTest 跑 app/src/androidTest/ 下的 WidgetSmokeTest +
+  # WidgetBddTest 共 9 条 executable BDD scenarios。
+  # 仅在 master push 触发避免拖慢 PR feedback (emulator 12-18 分钟首次启动)。
+  android-instrumented:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Strip aliyun mirrors for CI
+        run: sed -i '/maven\.aliyun\.com/d' settings.gradle.kts
+
+      - name: Enable KVM (required for hardware-accelerated emulator)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Grant execute permission to gradlew
+        run: chmod +x gradlew
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
+      - name: Run instrumented BDD tests on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 33
+          target: default
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: true
+          script: ./gradlew :app:connectedDebugAndroidTest --stacktrace
+
+      - name: Upload instrumented test report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: instrumented-test-report
+          path: app/build/reports/androidTests/
+          retention-days: 7


### PR DESCRIPTION
ci.yml 重新加 android-instrumented emulator job (Fix-W3 之前加过被 race wipe). master push 触发,真在 emulator 跑 9 条 widget BDD instrumented test.